### PR TITLE
Implement no file uploaded check

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ line_item_descriptions = {'book' => 'Book',
   4. `rails db:setup`
   5. `bundle exec figaro install`
   6. navigate to `/config/application.yml` and create variable CAT_API_KEY: <'Your-api-key-here'>
-  7. `bundle exec rspec` - there should be 30 passing examples
+  7. `bundle exec rspec` - there should be 31 passing examples
   8. `rails s`
   9. `navigate to localhost:3000`
 ## Deploying

--- a/app/controllers/baskets_controller.rb
+++ b/app/controllers/baskets_controller.rb
@@ -3,7 +3,7 @@
 class BasketsController < ApplicationController
   before_action :authenticate_user!
   before_action :correct_user, only: [:show, :destroy]
-  before_action :check_file_type, only: [:create]
+  before_action :check_no_file, :check_file_type, only: [:create]
 
   def index
     @baskets = current_user.baskets.order(created_at: :desc)
@@ -46,6 +46,13 @@ class BasketsController < ApplicationController
   def correct_user
     @basket = current_user.baskets.find_by(id: params[:id])
     redirect_to root_url if @basket.nil?
+  end
+
+  def check_no_file
+    if basket_params[:basket_file].nil?
+      flash[:error] = 'Please select a file to upload.'
+      redirect_to new_basket_path
+    end
   end
 
   def check_file_type

--- a/spec/features/baskets/create_basket_spec.rb
+++ b/spec/features/baskets/create_basket_spec.rb
@@ -67,4 +67,13 @@ RSpec.describe 'Basket Creation Page', type: :feature do
       expect(page).to have_content('File type not allowed')
     end
   end
+
+  describe 'I attempt to create a basket without uploading a file' do
+    it 'redirects me to the Basket create page with errors displayed' do
+      visit new_basket_path
+      click_button('Create')
+      expect(current_path).to eq(new_basket_path)
+      expect(page).to have_content('Please select a file to upload')
+    end
+  end
 end


### PR DESCRIPTION
## This PR...

Adds a commit will prevent users from attempting to skip uploading a file that would break the application. 

## Considerations and implementation

Implemented as a call back before the create action in the controller as a check

### Test(s) added

Added one test for the behavior expected when a user would try to click create without a file selected.

### Screenshots

![image](https://user-images.githubusercontent.com/68167430/129502691-e73bf9ec-7d44-4275-8278-25887360e294.png)
